### PR TITLE
add mutSigExtractor to github Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.0
 biocViews:
+Remotes: github::UMCUGenetics/mutSigExtractor
 Imports:
 	mutSigExtractor,
 	randomForest


### PR DESCRIPTION
This might help when installing CHORD from scratch, since mutSigExtractor isn't on CRAN.